### PR TITLE
feat: add function to test all images in a folder for the test set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ my_model.keras
 history_backup.pkl
 my_model_backup.keras
 node_modules
+test_set
+tmp


### PR DESCRIPTION
This pull request introduces changes to the `test_img.py` file. A new function to test all images in a specified folder. Used for the test set for summition

New functionality:

* Added a new function `test_all_images_in_folder` to test all images in a specified folder, sorting the images by numerical order in their filenames.